### PR TITLE
Python 3.11, ubuntu-22.04, revert to old tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Run tests for Ubuntu Python 2
         if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
         run: |
-          python2 dhash.py
+          python2 -m doctest dhash.py
+          pytest --cov=dhash test.py
       - name: Run tests for other setup configurations
         if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
         run: |
           python2 -m doctest dhash.py
-          pytest --cov=dhash test.py
+          python2 -m pytest --cov=dhash test.py
       - name: Run tests for other setup configurations
         if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
         run: |
           python -m doctest dhash.py
-          pytest --cov=dhash test.py
+          python -m pytest --cov=dhash test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['2.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,11 @@ jobs:
       - name: Install requirements for other setup configurations
         if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
         run: |
-          python --version
           pip install --upgrade pip
           pip install pytest pytest-cov Pillow Wand
       - name: Run tests for Ubuntu Python 2
         if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
         run: |
-          python2 --version
           python2 dhash.py
       - name: Run tests for other setup configurations
         if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,44 +6,72 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
+  test_ubuntu_python2:
+    runs-on: ubuntu-22.04
     strategy:
-      matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
-        python-version: ['2.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python for Ubuntu Python 2
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
-        run: |
-          sudo apt-get install python2
-          sudo apt-get install python-pip
       - name: Set up Python
-        if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
+        run: |
+          sudo apt-get install python2 python-pip
+
+      - name: Install requirements
+        run: |
+          pip2 install --upgrade pip
+          pip2 install pytest pytest-cov Pillow Wand
+
+      - name: Run tests
+        run: |
+          python2 -m doctest dhash.py
+          python2 -m pytest --cov=dhash test.py
+
+  test_ubuntu_python3:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install requirements for Ubuntu Python 2
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
-        run: |
-          pip2 install --upgrade pip
-          pip2 install pytest pytest-cov Pillow Wand
-      - name: Install requirements for other setup configurations
-        if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
+      - name: Install requirements
         run: |
           pip install --upgrade pip
           pip install pytest pytest-cov Pillow Wand
-      - name: Run tests for Ubuntu Python 2
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
+
+      - name: Run tests
         run: |
-          python2 -m doctest dhash.py
-          python2 -m pytest --cov=dhash test.py
-      - name: Run tests for other setup configurations
-        if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
+          python -m doctest dhash.py
+          python -m pytest --cov=dhash test.py
+
+  test_windows_and_macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install requirements
+        run: |
+          pip install --upgrade pip
+          pip install pytest pytest-cov Pillow Wand
+
+      - name: Run tests
         run: |
           python -m doctest dhash.py
           python -m pytest --cov=dhash test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,41 +10,41 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['2.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-22.04, windows-latest, macos-latest]
+        python-version: ['2.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Python for Ubuntu Python 2
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
         run: |
           sudo apt-get install python2
           sudo apt-get install python-pip
       - name: Set up Python
-        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7') }}
+        if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install requirements for Ubuntu Python 2
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
         run: |
           pip2 install --upgrade pip
           pip2 install pytest pytest-cov Pillow Wand
       - name: Install requirements for other setup configurations
-        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7') }}
+        if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
         run: |
           python --version
           pip install --upgrade pip
           pip install pytest pytest-cov Pillow Wand
       - name: Run tests for Ubuntu Python 2
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7' }}
         run: |
           python2 --version
           python2 dhash.py
       - name: Run tests for other setup configurations
-        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7') }}
+        if: ${{ !(matrix.os == 'ubuntu-22.04' && matrix.python-version == '2.7') }}
         run: |
           python -m doctest dhash.py
           pytest --cov=dhash test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,36 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Python for Ubuntu Python 2
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
+        run: |
+          sudo apt-get install python2
+          sudo apt-get install python-pip
       - name: Set up Python
+        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7') }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install requirements
+
+      - name: Install requirements for Ubuntu Python 2
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
+        run: |
+          pip2 install --upgrade pip
+          pip2 install pytest pytest-cov Pillow Wand
+      - name: Install requirements for other setup configurations
+        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7') }}
         run: |
           python --version
           pip install --upgrade pip
           pip install pytest pytest-cov Pillow Wand
-      - name: Run tests
+      - name: Run tests for Ubuntu Python 2
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
+        run: |
+          python2 --version
+          python2 dhash.py
+      - name: Run tests for other setup configurations
+        if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7') }}
         run: |
           python -m doctest dhash.py
           pytest --cov=dhash test.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 MANIFEST
 dist/
 build/
+.coverage

--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,9 @@ To produce a dhash value using wand:
 .. code:: python
 
     import dhash
-    from wand.image import Image as WandImage
+    import wand.image
 
-    with WandImage(filename='dhash-test.jpg') as image:
+    with wand.image.Image(filename='dhash-test.jpg') as image:
         row, col = dhash.dhash_row_col(image)
     print(dhash.format_hex(row, col))
 

--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,9 @@ To produce a dhash value using wand:
 .. code:: python
 
     import dhash
-    from wand.image import Image
+    from wand.image import Image as WandImage
 
-    with Image(filename='dhash-test.jpg') as image:
+    with WandImage(filename='dhash-test.jpg') as image:
         row, col = dhash.dhash_row_col(image)
     print(dhash.format_hex(row, col))
 

--- a/dhash.py
+++ b/dhash.py
@@ -14,8 +14,8 @@ import sys
 
 # Allow library to be imported even if neither wand or PIL are installed
 try:
-    import wand.image
     import wand.color
+    import wand.image
 except ImportError:
     wand = None
 
@@ -69,6 +69,12 @@ def get_grays(image, width, height, fill_color='white'):
 
     >>> get_grays([0,0,1,1,1, 0,1,1,3,4, 0,1,6,6,7, 7,7,7,7,9, 8,7,7,8,9], 5, 5)
     [0, 0, 1, 1, 1, 0, 1, 1, 3, 4, 0, 1, 6, 6, 7, 7, 7, 7, 7, 9, 8, 7, 7, 8, 9]
+
+    >>> import os
+    >>> test_filename = os.path.join(os.path.dirname(__file__), 'dhash-test.jpg')
+    >>> with wand.image.Image(filename=test_filename) as image:
+    ...     get_grays(image, 9, 9)[:18]
+    [95, 157, 211, 123, 94, 79, 75, 75, 78, 96, 116, 122, 113, 93, 75, 82, 81, 79]
     """
     if isinstance(image, (tuple, list)):
         if len(image) != width * height:
@@ -99,6 +105,12 @@ def dhash_row_col(image, size=8):
     '0100101111010001'
     >>> format(col, '016b')
     '0101001111111001'
+    >>> import os
+    >>> test_filename = os.path.join(os.path.dirname(__file__), 'dhash-test.jpg')
+    >>> with wand.image.Image(filename=test_filename) as image:
+    ...     row, col = dhash_row_col(image)
+    >>> (row, col) == (13962536140006260880, 9510476289765573406)
+    True
     """
     width = size + 1
     grays = get_grays(image, width, width)

--- a/dhash.py
+++ b/dhash.py
@@ -15,7 +15,7 @@ import sys
 # Allow library to be imported even if neither wand or PIL are installed
 try:
     import wand.color
-    from wand.image import Image as WandImage
+    import wand.image
 except ImportError:
     wand = None
 
@@ -80,7 +80,7 @@ def get_grays(image, width, height, fill_color='white'):
     if wand is None and PIL is None:
         raise ImportError('must have wand or Pillow/PIL installed to use dhash on images')
 
-    if wand is not None and isinstance(image, WandImage):
+    if wand is not None and isinstance(image, wand.image.Image):
         return _get_grays_wand(image, width, height, fill_color)
     elif PIL is not None and isinstance(image, PIL.Image.Image):
         return _get_grays_pil(image, width, height, fill_color)
@@ -260,7 +260,7 @@ if __name__ == '__main__':
 
     def load_image(filename):
         if wand is not None:
-            return WandImage(filename=filename)
+            return wand.image.Image(filename=filename)
         elif PIL is not None:
             return PIL.Image.open(filename)
         else:

--- a/dhash.py
+++ b/dhash.py
@@ -15,7 +15,7 @@ import sys
 # Allow library to be imported even if neither wand or PIL are installed
 try:
     import wand.color
-    import wand.image
+    from wand.image import Image as WandImage
 except ImportError:
     wand = None
 
@@ -69,12 +69,6 @@ def get_grays(image, width, height, fill_color='white'):
 
     >>> get_grays([0,0,1,1,1, 0,1,1,3,4, 0,1,6,6,7, 7,7,7,7,9, 8,7,7,8,9], 5, 5)
     [0, 0, 1, 1, 1, 0, 1, 1, 3, 4, 0, 1, 6, 6, 7, 7, 7, 7, 7, 9, 8, 7, 7, 8, 9]
-
-    >>> import os
-    >>> test_filename = os.path.join(os.path.dirname(__file__), 'dhash-test.jpg')
-    >>> with wand.image.Image(filename=test_filename) as image:
-    ...     get_grays(image, 9, 9)[:18]
-    [95, 157, 211, 123, 94, 79, 75, 75, 78, 96, 116, 122, 113, 93, 75, 82, 81, 79]
     """
     if isinstance(image, (tuple, list)):
         if len(image) != width * height:
@@ -86,7 +80,7 @@ def get_grays(image, width, height, fill_color='white'):
     if wand is None and PIL is None:
         raise ImportError('must have wand or Pillow/PIL installed to use dhash on images')
 
-    if wand is not None and isinstance(image, wand.image.Image):
+    if wand is not None and isinstance(image, WandImage):
         return _get_grays_wand(image, width, height, fill_color)
     elif PIL is not None and isinstance(image, PIL.Image.Image):
         return _get_grays_pil(image, width, height, fill_color)
@@ -105,12 +99,6 @@ def dhash_row_col(image, size=8):
     '0100101111010001'
     >>> format(col, '016b')
     '0101001111111001'
-    >>> import os
-    >>> test_filename = os.path.join(os.path.dirname(__file__), 'dhash-test.jpg')
-    >>> with wand.image.Image(filename=test_filename) as image:
-    ...     row, col = dhash_row_col(image)
-    >>> (row, col) == (13962536140006260880, 9510476289765573406)
-    True
     """
     width = size + 1
     grays = get_grays(image, width, width)
@@ -272,7 +260,7 @@ if __name__ == '__main__':
 
     def load_image(filename):
         if wand is not None:
-            return wand.image.Image(filename=filename)
+            return WandImage(filename=filename)
         elif PIL is not None:
             return PIL.Image.open(filename)
         else:

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 import os
 import re
 import sys
-from setuptools import setup
 
+from setuptools import setup
 
 # Read files as byte strings on Python 2.x, unicode strings on 3.x
 if sys.version_info < (3, 0):
@@ -53,6 +53,11 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Multimedia :: Graphics',
     ]
 )

--- a/test.py
+++ b/test.py
@@ -1,9 +1,10 @@
-from unittest import TestCase
 from io import BytesIO
 from os import path
-from PIL import Image as PilImage, ImageDraw as PilDraw
+from unittest import TestCase
 
-from wand.image import Image as WandImage
+import wand.image
+from PIL import Image as PilImage
+from PIL import ImageDraw as PilDraw
 
 import dhash
 
@@ -14,7 +15,7 @@ def pil_to_wand(image, format="png"):
     with BytesIO() as fd:
         image.save(fd, format=format)
         fd.seek(0)
-        return WandImage(file=fd)
+        return wand.image.Image(file=fd)
 
 
 class TestDHash(TestCase):
@@ -23,7 +24,7 @@ class TestDHash(TestCase):
             self._test_get_grays(image, delta=1)
 
     def test_get_grays_wand(self):
-        image = WandImage(filename=path.join(IMGDIR, "dhash-test.jpg"))
+        image = wand.image.Image(filename=path.join(IMGDIR, "dhash-test.jpg"))
         self._test_get_grays(image, delta=2)
 
     def _test_get_grays(self, image, delta):

--- a/test.py
+++ b/test.py
@@ -1,17 +1,16 @@
 from unittest import TestCase
 from io import BytesIO
 from os import path
-
 from PIL import Image as PilImage, ImageDraw as PilDraw
+
 from wand.image import Image as WandImage
 
 import dhash
 
-
 IMGDIR = path.dirname(__file__)
 
 
-def pil_to_wand(image, format='png'):
+def pil_to_wand(image, format="png"):
     with BytesIO() as fd:
         image.save(fd, format=format)
         fd.seek(0)
@@ -20,11 +19,11 @@ def pil_to_wand(image, format='png'):
 
 class TestDHash(TestCase):
     def test_get_grays_pil(self):
-        with PilImage.open(path.join(IMGDIR, 'dhash-test.jpg')) as image:
+        with PilImage.open(path.join(IMGDIR, "dhash-test.jpg")) as image:
             self._test_get_grays(image, delta=1)
 
     def test_get_grays_wand(self):
-        image = WandImage(filename=path.join(IMGDIR, 'dhash-test.jpg'))
+        image = WandImage(filename=path.join(IMGDIR, "dhash-test.jpg"))
         self._test_get_grays(image, delta=2)
 
     def _test_get_grays(self, image, delta):
@@ -42,8 +41,8 @@ class TestDHash(TestCase):
     def test_fill_transparency(self):
         "Ensure transparent colors in PIL Images are ignored in hashes"
 
-        # greyscale image, completely white and also completely transparent
-        im1 = PilImage.new('LA', (100, 100), (0xff, 0))
+        # grayscale image, completely white and also completely transparent
+        im1 = PilImage.new("LA", (100, 100), (0xFF, 0))
 
         im2 = im1.copy()
         # replace most of it with "transparent black"
@@ -57,6 +56,7 @@ class TestDHash(TestCase):
         self.assertAlmostEqual(dhash.dhash_row_col(pm1), dhash.dhash_row_col(pm2), delta=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import unittest
+
     unittest.main()


### PR DESCRIPTION
- It turns out that the old tests replaced in #11 are working fine in `ubuntu-22.04`, likely due to the outdated version of wand used in `ubuntu-20.04`. Therefore I have reverted to the old tests.

- GitHub will change `ubuntu-latest`  to be based on `ubuntu-22.04` by the [end of this month](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04).

- In `ubuntu-22.04`, Python 2 and pip2 have to be manually installed; **ci.yml** has been updated for this.

- Added Python 3.11

- Added `.coverage` to **.gitignore**
